### PR TITLE
Refactor data fetching with lint-ready setup

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,26 @@
+import google from 'eslint-config-google';
+import reactPlugin from 'eslint-plugin-react';
+
+export default [
+  google,
+  {
+    files: ['**/*.{js,jsx}'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: {
+        window: 'readonly',
+        document: 'readonly',
+      },
+    },
+    plugins: {
+      react: reactPlugin,
+    },
+    rules: {
+      'max-len': ['error', {code: 120}],
+      'require-jsdoc': 'off',
+      'react/react-in-jsx-scope': 'off',
+    },
+  },
+];
+

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",
-    "lint": "echo \"No linting configured\""
+    "lint": "eslint ."
   },
   "devDependencies": {
     "@babel/core": "^7.25.7",
@@ -28,7 +28,10 @@
     "css-loader": "^6.11.0",
     "electron": "32.1.2",
     "node-loader": "^2.0.0",
-    "style-loader": "^3.3.4"
+    "style-loader": "^3.3.4",
+    "eslint": "^9.11.1",
+    "eslint-config-google": "^0.14.0",
+    "eslint-plugin-react": "^7.34.3"
   },
   "keywords": [],
   "author": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,10 @@
 import React from "react";
 import DataFetch from "./components/DataFetch/DataFetch.jsx";
 
+/**
+ * Root application component.
+ * @return {JSX.Element}
+ */
 function App() {
   return (
     <div>
@@ -10,3 +14,4 @@ function App() {
 }
 
 export default App;
+

--- a/src/components/DataFetch/DataFetch.jsx
+++ b/src/components/DataFetch/DataFetch.jsx
@@ -1,63 +1,47 @@
-import React, { useEffect, useState } from 'react';
+import React, {useEffect, useState} from 'react';
 import './DataFetch.css';
 import SongContainer from '../SongContainer/SongContainer.jsx';
-const { ipcRenderer } = window.require('electron');
+import {fetchSongs} from '../../services/songApi.js';
 
-//https://rhythmverse.co/api/yarg/songfiles/list
-
-const listEndpoint = 'https://rhythmverse.co/api/yarg/songfiles/list'
-const searchEndpoint = 'https://rhythmverse.co/api/yarg/songfiles/search/live'
-
-const formData = new URLSearchParams();
-formData.append('sort[0][sort_by]', 'downloads');
-formData.append('sort[0][sort_order]', 'DESC');
-formData.append('data_type', 'full');
-formData.append('text', '');
-formData.append('page', 1);
-formData.append('records', 25);
-
+/**
+ * Fetches data from the YARG API and renders the song container.
+ * @return {JSX.Element}
+ */
 function DataFetch() {
   const [data, setData] = useState({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [search, setSearch] = useState("");
+  const [search, setSearch] = useState('');
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(null);
   const [totalRecords, setTotalRecords] = useState(0);
   const [pageSize, setPageSize] = useState(25);
 
   useEffect(() => {
-    async function fetchData() {
+    async function loadData() {
       setLoading(true);
 
-      formData.set('page', page);
-      formData.set('records', pageSize == -1 ? totalRecords : pageSize)
-      if (search.length < 3) {
-        formData.delete('text');
-      } else {
-        formData.set('text', search);
-      }
-
-      const formDataObj = Object.fromEntries(formData);
-      const result = await ipcRenderer.invoke('fetch-data', search.length < 3 ? listEndpoint : searchEndpoint, formDataObj);
+      const params = buildQueryParams(search, page, pageSize, totalRecords);
+      const result = await fetchSongs(params, search.length >= 3);
 
       if (result.error) {
         setError(result.error);
       } else {
         setData(result);
-        setTotalPages(result.data.records.total_filtered / result.data.records.returned)
-        setTotalRecords(result.data.records.total_filtered)
+        setTotalPages(result.data.records.total_filtered /
+            result.data.records.returned);
+        setTotalRecords(result.data.records.total_filtered);
       }
 
       setLoading(false);
     }
 
-    fetchData();
+    loadData();
   }, [search, page, pageSize]);
 
   return (
     <div>
-      <SongContainer 
+      <SongContainer
         data={data.data}
         page={page}
         setPage={setPage}
@@ -65,7 +49,8 @@ function DataFetch() {
         setTotalPages={setTotalPages}
         pageSize={pageSize}
         setPageSize={setPageSize}
-        search={search} setSearch={setSearch}
+        search={search}
+        setSearch={setSearch}
         loading={loading}
         error={error}
       />
@@ -73,4 +58,26 @@ function DataFetch() {
   );
 }
 
+/**
+ * Builds query parameters for the song API.
+ * @param {string} search Search text.
+ * @param {number} page Current page number.
+ * @param {number} pageSize Number of records per page.
+ * @param {number} totalRecords Total records available.
+ * @return {Object<string, string|number>} Query parameters.
+ */
+function buildQueryParams(search, page, pageSize, totalRecords) {
+  const params = new URLSearchParams();
+  params.set('sort[0][sort_by]', 'downloads');
+  params.set('sort[0][sort_order]', 'DESC');
+  params.set('data_type', 'full');
+  params.set('page', String(page));
+  params.set('records', String(pageSize === -1 ? totalRecords : pageSize));
+  if (search.length >= 3) {
+    params.set('text', search);
+  }
+  return Object.fromEntries(params);
+}
+
 export default DataFetch;
+

--- a/src/components/SongContainer/SongContainer.jsx
+++ b/src/components/SongContainer/SongContainer.jsx
@@ -1,13 +1,29 @@
-import React, { useState } from 'react';
+import React from 'react';
 import SongList from '../SongList/SongList.jsx';
 import './SongContainer.css';
 import SearchInput from '../SearchInput/SearchInput.jsx';
 import Pagination from '../Pagination/Pagination.jsx';
 
-function SongContainer({ data, page, setPage, totalPages, setTotalPages, pageSize, setPageSize, search, setSearch, loading, error }) {
-
+/**
+ * Displays song results with pagination and search controls.
+ * @param {Object} props Component properties.
+ * @param {Object} props.data Song data from the API.
+ * @param {number} props.page Current page number.
+ * @param {Function} props.setPage Setter for page number.
+ * @param {number|null} props.totalPages Total available pages.
+ * @param {Function} props.setTotalPages Setter for total pages.
+ * @param {number} props.pageSize Number of records per page.
+ * @param {Function} props.setPageSize Setter for page size.
+ * @param {string} props.search Current search query.
+ * @param {Function} props.setSearch Setter for search query.
+ * @param {boolean} props.loading Loading state flag.
+ * @param {?Error} props.error API error if any.
+ * @return {JSX.Element}
+ */
+function SongContainer({data, page, setPage, totalPages, setTotalPages, pageSize,
+  setPageSize, search, setSearch, loading, error}) {
   return (
-    <div className=".container">
+    <div className="container">
       <div className="filter">
         <div className="files">
           <h1>{!loading && !error ? data.records.total_filtered : 0}</h1>
@@ -18,17 +34,24 @@ function SongContainer({ data, page, setPage, totalPages, setTotalPages, pageSiz
         </div>
       </div>
       <hr />
-      {error ? <div>Error: {error.message}</div> : loading ? <div className="spinner-container">
-        <h1>Loading...</h1>
-        <div className="spinner"></div>
-      </div> : <div>
-        <SongList songs={data.songs} />
-        <Pagination page={page} setPage={setPage} totalPages={totalPages} setTotalPages={setTotalPages} pageSize={pageSize} setPageSize={setPageSize}  />
-      </div>
-      }
-
+      {error ? (
+        <div>Error: {error.message}</div>
+      ) : loading ? (
+        <div className="spinner-container">
+          <h1>Loading...</h1>
+          <div className="spinner"></div>
+        </div>
+      ) : (
+        <div>
+          <SongList songs={data.songs} />
+          <Pagination page={page} setPage={setPage} totalPages={totalPages}
+            setTotalPages={setTotalPages} pageSize={pageSize}
+            setPageSize={setPageSize} />
+        </div>
+      )}
     </div>
-  )
+  );
 }
 
 export default SongContainer;
+

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
-import App from "./app.jsx";
+import App from "./App.jsx";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
@@ -9,3 +9,4 @@ root.render(
     <App />
   </React.StrictMode>
 );
+

--- a/src/services/songApi.js
+++ b/src/services/songApi.js
@@ -1,0 +1,16 @@
+const {ipcRenderer} = window.require('electron');
+
+const LIST_ENDPOINT = 'https://rhythmverse.co/api/yarg/songfiles/list';
+const SEARCH_ENDPOINT = 'https://rhythmverse.co/api/yarg/songfiles/search/live';
+
+/**
+ * Fetches song data from the YARG API.
+ * @param {Object<string, string|number>} params Query parameters.
+ * @param {boolean} useSearch Whether to use the search endpoint.
+ * @return {Promise<Object>} API response data.
+ */
+export async function fetchSongs(params, useSearch) {
+  const endpoint = useSearch ? SEARCH_ENDPOINT : LIST_ENDPOINT;
+  return ipcRenderer.invoke('fetch-data', endpoint, params);
+}
+


### PR DESCRIPTION
## Summary
- Modularize song API access into a dedicated service
- Clean up React components and adopt Google-style structure
- Introduce ESLint configuration for Google and React

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-google')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689940627d948326962f3100dd7116ea